### PR TITLE
docs: CITATION.cff + landing-page meta description

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,28 @@
+cff-version: 1.2.0
+message: "If you use nix-license, please cite it using these metadata."
+title: nix-license
+abstract: >-
+  A NixOS module that checks every package's license against your declared
+  usage at build time, replacing the global allowUnfree flag. You declare your
+  usage context (personal/commercial, distribution, modifications, SaaS) and
+  required assurances (source-available, patent grants, warranty); the module
+  enforces per-package, per-context license restrictions and obligations. It
+  carries the SALT license classification, full nixpkgs license coverage, an
+  OARS content policy, a GitHub Action, JSON/HTML compliance reports, and
+  GPG/YubiKey cryptographic verification.
+type: software
+authors:
+  - given-names: Ido
+    family-names: Samuelson
+    website: "https://github.com/i-am-logger"
+repository-code: "https://github.com/i-am-logger/nix-license"
+url: "https://nix-license.dev/"
+license: CC-BY-NC-SA-4.0
+version: 0.13.0
+keywords:
+  - nixos
+  - license-compliance
+  - spdx
+  - sbom
+  - software-composition-analysis
+  - supply-chain-security

--- a/docs/presentations/compliance-overview.md
+++ b/docs/presentations/compliance-overview.md
@@ -1,5 +1,9 @@
 ---
 marp: true
+title: "nix-license — license compliance for NixOS at build time"
+description: "nix-license is a NixOS module that enforces software license compliance at build time against your declared usage — SPDX-aware, SBOM-ready, with a GitHub Action and signed reports."
+keywords: "NixOS, license compliance, SPDX, SBOM, allowUnfree, supply chain, OpenChain"
+url: "https://nix-license.dev/"
 theme: default
 paginate: true
 backgroundColor: #0d1117


### PR DESCRIPTION
Two small discoverability additions, no code change:

- **`CITATION.cff`** — GitHub renders a "Cite this repository" button (BibTeX/APA), a credibility signal that fits a license-compliance/governance tool.
- **Landing-page meta description** — `nix-license.dev` currently ships **no** `<meta name="description">` (the biggest on-page SEO gap). Added via Marp front-matter (`title`/`description`/`keywords`/`url`) on `docs/presentations/compliance-overview.md`, so the next CI Pages build emits the meta + OGP tags.